### PR TITLE
Temporarily disable modal overlay

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import Navbar from "./components/navbar";
-import { Suspense } from "react";
 import ModalOverlay from "./components/modal-overlay";
 import Link from "next/link";
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,7 +23,6 @@ export default function RootLayout({
       <body className={inter.className}>
         <Navbar />
         {children}
-        <ModalOverlay />
       </body>
     </html>
   );


### PR DESCRIPTION
Remove the `<ModalOverlay />` component from the layout page. The actual fix will be requested in another issue.

Closes #19