### PR TITLE
Migrate from framer-motion to motion/react

### DIFF
--- a/app/about-us/history/page.tsx
+++ b/app/about-us/history/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect, useMemo, useState } from 'react';
-import { motion } from 'framer-motion';
+import { motion } from 'motion/react';
 import HistorySummary from '@/app/components/about-us/history/summary';
 import Timeline from '@/app/components/about-us/history/timeline';
 import VideoFrame from '@/app/components/about-us/history/video-frame';

--- a/app/components/animations.tsx
+++ b/app/components/animations.tsx
@@ -1,9 +1,9 @@
 /**
- * Contains React components to wrap other components in framer-motion animations.
+ * Contains React components to wrap other components in motion/react animations.
  */
 
 import React from "react";
-import { motion } from "framer-motion";
+import { motion } from "motion/react";
 
 // TODO: add type checking
 // @ts-ignore

--- a/app/components/our-team/team-card.tsx
+++ b/app/components/our-team/team-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import Image from "next/image";
-import { motion } from "framer-motion";
+import { motion } from "motion/react";
 
 
 interface TeamCardProps {

--- a/app/components/scroll-to-top.tsx
+++ b/app/components/scroll-to-top.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {useEffect} from "react";
-import {useAnimationControls, useScroll, motion, Variants} from "framer-motion";
+import {useAnimationControls, useScroll, motion, Variants} from "motion/react";
 import {FaArrowAltCircleUp, FaArrowCircleUp, FaArrowUp} from "react-icons/fa"
 
 const isBrowser = () => typeof window != 'undefined';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "framer-motion": "^11.11.9",
+        "motion": "^12.0.5",
         "next": "^14.2.5",
         "react": "^18",
         "react-dom": "^18",
@@ -4413,31 +4413,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/framer-motion": {
-      "version": "11.11.9",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.11.9.tgz",
-      "integrity": "sha512-XpdZseuCrZehdHGuW22zZt3SF5g6AHJHJi7JwQIigOznW4Jg1n0oGPMJQheMaKLC+0rp5gxUKMRYI6ytd3q4RQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6579,6 +6554,70 @@
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/motion": {
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.0.5.tgz",
+      "integrity": "sha512-AFCMJWX7xtd2V4PEuL+FnVscw++SaMZuFXrm3kjN1sIqrNDJdJrFbZ2B+pfq6CKlcTor/vVJcmrc2pJqF3EByw==",
+      "dependencies": {
+        "framer-motion": "^12.0.5",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.0.0.tgz",
+      "integrity": "sha512-CvYd15OeIR6kHgMdonCc1ihsaUG4MYh/wrkz8gZ3hBX/uamyZCXN9S9qJoYF03GqfTt7thTV/dxnHYX4+55vDg==",
+      "dependencies": {
+        "motion-utils": "^12.0.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.0.0.tgz",
+      "integrity": "sha512-MNFiBKbbqnmvOjkPyOKgHUp3Q6oiokLkI1bEwm5QA28cxMZrv0CbbBGDNmhF6DIXsi1pCQBSs0dX8xjeER1tmA=="
+    },
+    "node_modules/motion/node_modules/framer-motion": {
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.0.5.tgz",
+      "integrity": "sha512-OgfUHfL+u80uCf6VzkV7j3+H2W9zPMdV+40bug4ftB0C2+0FpfNca2rbH2Fouq2R7//bjw6tJhOwXsrsM4+LKw==",
+      "dependencies": {
+        "motion-dom": "^12.0.0",
+        "motion-utils": "^12.0.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "framer-motion": "^11.11.9",
+    "motion": "^12.0.5",
     "next": "^14.2.5",
     "react": "^18",
     "react-dom": "^18",


### PR DESCRIPTION
The framer-motion npm package is changing to motion/react. The old documentation website is no longer available. The new docs can be found [here](motion.dev).