### PR TITLE
Fix hash navigation issue in Contact Us Page

### DIFF
--- a/app/contact-us/page.tsx
+++ b/app/contact-us/page.tsx
@@ -61,6 +61,17 @@ export default function ContactPage() {
             });
     }, []);
 
+    useEffect(() => {
+        const hash = window.location.hash;
+        if (hash) {
+            const elementId = hash.substring(1); // Remove the '#' from the hash
+            const element = document.getElementById(elementId);
+            if (element) {
+                element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        }
+    }, [businessFormConfig, generalFormConfig]);
+
     return (
         <div className="items-center px-4 md:px-12 lg:px-16 pb-12">
             <Suspense>


### PR DESCRIPTION
This pull request adds functionality to handle URL hash navigation on the `ContactPage` component, ensuring smooth scrolling to the corresponding element when a hash is present in the URL.

### Enhancements to user navigation:

* [`app/contact-us/page.tsx`](diffhunk://#diff-0900555738560216ea63d0ccf407d1607d0d0e0d14b98e0c6c37b0f1e8628e2aR64-R74): Introduced a `useEffect` hook to detect URL hash changes and smoothly scroll to the corresponding element on the page using `scrollIntoView`.

### Related Issues
* Resolve #95 